### PR TITLE
[Implement] GitHub Actions のWorkflow バージョンを最新に引き上げた

### DIFF
--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -5,6 +5,9 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-2025-vs2026
@@ -13,6 +16,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v3

--- a/.github/workflows/build-test-with-msvc.yml
+++ b/.github/workflows/build-test-with-msvc.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: windows-2025-vs2026
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1
+        uses: NuGet/setup-nuget@v4
 
       - name: Restore Nuget Packages
         run: |

--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -37,7 +37,7 @@ jobs:
           echo "key=$key" >> $GITHUB_OUTPUT
 
       - if: ${{ inputs.use-ccache }}
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ steps.calculate-cache-key.outputs.key }}
           max-size: "200M"

--- a/.github/workflows/build-with-autotools.yml
+++ b/.github/workflows/build-with-autotools.yml
@@ -22,6 +22,9 @@ on:
         type: boolean
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
@@ -29,6 +32,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - id: calculate-cache-key
         name: Calculate cache key for ccache

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish Release Page
     runs-on: windows-2025-vs2026
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -24,10 +24,10 @@ jobs:
           echo "version=$version" >> $Env:GITHUB_OUTPUT
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1
+        uses: NuGet/setup-nuget@v4
 
       - name: Restore Nuget Packages
         run: |
@@ -38,7 +38,7 @@ jobs:
           .\Build-Windows-Release-Package.ps1 -Version ${{ steps.get_version.outputs.version }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: Hengband-*.zip
           fail_on_unmatched_files: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,10 +12,13 @@ jobs:
   publish-release-page:
     name: Publish Release Page
     runs-on: windows-2025-vs2026
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Extract version from configure.ac
         id: get_version

--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create auto generate spoiler files
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -39,7 +39,7 @@ jobs:
         run: nkf -w --in-place ~/.angband/Hengband/*.txt
 
       - name: Upload spoilers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spoiler-files
           path: ~/.angband/Hengband/*.txt
@@ -52,12 +52,12 @@ jobs:
     env:
       GITHUB_PAGES_REPOSITORY: hengband/spoiler
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           repository: ${{ env.GITHUB_PAGES_REPOSITORY }}
 
       - name: Download spoilers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: spoiler-files
           path: spoilers
@@ -66,7 +66,7 @@ jobs:
         run: cp -v spoilers/*.txt docs/
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.SPOILER_REPOSITORY_DEPLOY_KEY }}
           publish_dir: ./docs

--- a/.github/workflows/publish-spoiler-page.yml
+++ b/.github/workflows/publish-spoiler-page.yml
@@ -6,6 +6,9 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   create_spoilers:
     name: Create auto generate spoiler files
@@ -14,6 +17,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Install required packages
         run: |
@@ -55,6 +59,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           repository: ${{ env.GITHUB_PAGES_REPOSITORY }}
+          persist-credentials: false
 
       - name: Download spoilers
         uses: actions/download-artifact@v8

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -12,21 +12,21 @@ jobs:
     name: Check the BOM of the source files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - run: sh ./.github/scripts/check-bom.sh
 
   check_newline:
     name: Check the newline of files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - run: sh ./.github/scripts/check-newline.sh
 
   check_format:
     name: Check the format of the source files
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Check the format of the cpp source and header files
         run: sh ./.github/scripts/check-cpp-format.sh
       - name: Check the format of the json/jsonc files
@@ -36,7 +36,7 @@ jobs:
     name: Check include directive style ("" vs <>)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: python3 .github/scripts/check-include-style.py
 
   build_test_clang15_libcpp_without_pch:
@@ -89,10 +89,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.14'
 

--- a/.github/workflows/pull-request-status-check.yml
+++ b/.github/workflows/pull-request-status-check.yml
@@ -7,12 +7,17 @@ on:
   # 手動トリガーを許可
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_bom:
     name: Check the BOM of the source files
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: sh ./.github/scripts/check-bom.sh
 
   check_newline:
@@ -20,6 +25,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: sh ./.github/scripts/check-newline.sh
 
   check_format:
@@ -27,6 +34,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Check the format of the cpp source and header files
         run: sh ./.github/scripts/check-cpp-format.sh
       - name: Check the format of the json/jsonc files
@@ -37,6 +46,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: python3 .github/scripts/check-include-style.py
 
   build_test_clang15_libcpp_without_pch:
@@ -90,6 +101,8 @@ jobs:
     steps:
       - name: Repository checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
ビルド可能か否かをチェックする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD ワークフローで使用する GitHub Actions を最新バージョンに更新しました。
  * ビルド、テスト、リリース、アーティファクト処理、GitHub Pages デプロイの安定性と保守性を向上しました。
  * チェックアウト時の認証情報保存を無効化し、ワークフロー権限を必要最小限に見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->